### PR TITLE
5차 배포

### DIFF
--- a/src/main/java/uos/samsam/wing/SwaggerConfig.java
+++ b/src/main/java/uos/samsam/wing/SwaggerConfig.java
@@ -2,11 +2,17 @@ package uos.samsam.wing;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RequestMethod;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.builders.ResponseMessageBuilder;
+import springfox.documentation.service.ResponseMessage;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Configuration
 @EnableSwagger2
@@ -15,6 +21,7 @@ public class SwaggerConfig {
     @Bean
     public Docket api(){
         return new Docket(DocumentationType.SWAGGER_2)
+                .useDefaultResponseMessages(false)
                 .groupName("API v1 - 20210328")
                 .select()
                 .apis(RequestHandlerSelectors.any())

--- a/src/main/java/uos/samsam/wing/service/report/ReportService.java
+++ b/src/main/java/uos/samsam/wing/service/report/ReportService.java
@@ -26,6 +26,7 @@ public class ReportService {
         return reportRepository.save(requestDto.toEntity(padBox.get())).getId();
     }
 
+    @Transactional(readOnly = true)
     public ReportResponseDto findById(Long id) {
         Report entity = reportRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 신고가 없습니다. id=" + id));

--- a/src/main/java/uos/samsam/wing/web/GlobalExceptionHandler.java
+++ b/src/main/java/uos/samsam/wing/web/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package uos.samsam.wing.web;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
@@ -10,8 +12,10 @@ import java.util.Map;
 @ControllerAdvice
 @RestController
 public class GlobalExceptionHandler {
-    @ExceptionHandler(value = Exception.class)
-    public Map<String, String> handleException(Exception e) {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(value = IllegalArgumentException.class)
+    public Map<String, String> handleException(IllegalArgumentException e) {
         Map<String, String> map = new HashMap<>();
         map.put("errMsg", e.getMessage());
         return map;

--- a/src/main/java/uos/samsam/wing/web/UserApiController.java
+++ b/src/main/java/uos/samsam/wing/web/UserApiController.java
@@ -1,5 +1,9 @@
 package uos.samsam.wing.web;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,6 +13,7 @@ import uos.samsam.wing.service.user.UserService;
 import uos.samsam.wing.web.dto.UserLoginRequestDto;
 import uos.samsam.wing.web.dto.UserSaveRequestDto;
 
+@Api(value = "UserApiController v1")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin")
 @RestController
@@ -16,11 +21,23 @@ public class UserApiController {
 
     private final UserService userService;
 
+    @ApiOperation(value = "로그인", notes = "관리자로 로그인합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "로그인 성공"),
+            @ApiResponse(code = 400, message = "존재하지 않는 ID거나 PW가 틀림"),
+            @ApiResponse(code = 500, message = "서버 내부 에러")
+    })
     @PostMapping("/login")
     public String login(@RequestBody UserLoginRequestDto requestDto) {
         return userService.login(requestDto);
     }
 
+    @ApiOperation(value = "회원가입(테스트용)", notes = "새로운 관리자 계정을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "회원 생성 성공"),
+            @ApiResponse(code = 400, message = "잘못된 요청"),
+            @ApiResponse(code = 500, message = "서버 내부 에러")
+    })
     @PostMapping("/join")
     public Long join(@RequestBody UserSaveRequestDto requestDto) {
         return userService.join(requestDto);

--- a/src/main/java/uos/samsam/wing/web/dto/NoticeResponseDto.java
+++ b/src/main/java/uos/samsam/wing/web/dto/NoticeResponseDto.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import uos.samsam.wing.domain.notice.Notice;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class NoticeResponseDto {
@@ -12,10 +14,12 @@ public class NoticeResponseDto {
     private Long id;
     private String title;
     private String content;
+    private LocalDateTime createdDate;
 
     public NoticeResponseDto(Notice entity) {
         this.id = entity.getId();
         this.title = entity.getTitle();
         this.content = entity.getContent();
+        this.createdDate = entity.getCreatedDate();
     }
 }

--- a/src/main/java/uos/samsam/wing/web/dto/ReportResponseDto.java
+++ b/src/main/java/uos/samsam/wing/web/dto/ReportResponseDto.java
@@ -6,21 +6,25 @@ import uos.samsam.wing.domain.padbox.PadBox;
 import uos.samsam.wing.domain.report.Report;
 import uos.samsam.wing.domain.report.ReportTag;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class ReportResponseDto {
 
     private Long id;
-    private PadBox padBox;
+    private PadBoxResponseDto padBox;
     private ReportTag tag;
     private String content;
     private Boolean isResolved;
+    private LocalDateTime createdDate;
 
     public ReportResponseDto(Report entity) {
         this.id = entity.getId();
-        this.padBox = entity.getPadBox();
+        this.padBox = new PadBoxResponseDto(entity.getPadBox());
         this.tag = entity.getTag();
         this.content = entity.getContent();
         this.isResolved = entity.getIsResolved();
+        this.createdDate = entity.getCreatedDate();
     }
 }

--- a/src/test/java/uos/samsam/wing/service/notice/NoticeServiceTest.java
+++ b/src/test/java/uos/samsam/wing/service/notice/NoticeServiceTest.java
@@ -11,6 +11,7 @@ import uos.samsam.wing.web.dto.NoticeResponseDto;
 import uos.samsam.wing.web.dto.NoticeSaveRequestDto;
 import uos.samsam.wing.web.dto.NoticeUpdateRequestDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,6 +45,7 @@ class NoticeServiceTest {
         NoticeResponseDto responseDto = noticeService.findById(noticeId);
         assertThat(responseDto.getTitle()).isEqualTo(title);
         assertThat(responseDto.getContent()).isEqualTo(content);
+        assertThat(responseDto.getCreatedDate()).isBefore(LocalDateTime.now());
     }
 
     @Test

--- a/src/test/java/uos/samsam/wing/service/report/ReportServiceTest.java
+++ b/src/test/java/uos/samsam/wing/service/report/ReportServiceTest.java
@@ -14,6 +14,7 @@ import uos.samsam.wing.web.dto.ReportResponseDto;
 import uos.samsam.wing.web.dto.ReportSaveRequestDto;
 import uos.samsam.wing.web.dto.ReportUpdateRequestDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,6 +65,7 @@ class ReportServiceTest {
         assertThat(responseDto.getTag()).isEqualTo(tag);
         assertThat(responseDto.getContent()).isEqualTo(content);
         assertThat(responseDto.getIsResolved()).isEqualTo(isResolved);
+        assertThat(responseDto.getCreatedDate()).isBefore(LocalDateTime.now());
     }
 
     @Test

--- a/src/test/java/uos/samsam/wing/web/UserApiControllerTest.java
+++ b/src/test/java/uos/samsam/wing/web/UserApiControllerTest.java
@@ -147,12 +147,8 @@ class UserApiControllerTest {
         String url = preUrl + "login";
 
         //when, then
-        MvcResult result = mvc.perform(post(url).contentType(MediaType.APPLICATION_JSON)
+        mvc.perform(post(url).contentType(MediaType.APPLICATION_JSON)
                 .content(new ObjectMapper().writeValueAsString(requestDto)))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        System.out.println("result = " + result.getResponse().getContentAsString());
-        assertThat(result.getResponse().getContentAsString().length()).isGreaterThan(0);
+                .andExpect(status().isBadRequest());  //인증 실패
     }
 }


### PR DESCRIPTION
- `ReportResponse` 에서 `PadBox` Entity로 인해 순환 참조 발생하는 문제 해결
- 로그인 실패 시 HTTP code 200 대신 400(Bad Request)으로 반환하게 수정
- Swagger API 문서에 `AdminApiController`에 대한 상세한 설명 추가
    - 나머지 Controller는 추후 추가 예정