### PR TITLE
API에서 온습도 관련 정보 삭제

### DIFF
--- a/src/main/java/uos/samsam/wing/SwaggerConfig.java
+++ b/src/main/java/uos/samsam/wing/SwaggerConfig.java
@@ -2,17 +2,11 @@ package uos.samsam.wing;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.bind.annotation.RequestMethod;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.builders.ResponseMessageBuilder;
-import springfox.documentation.service.ResponseMessage;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * SwaggerConfig

--- a/src/main/java/uos/samsam/wing/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/uos/samsam/wing/auth/JwtAuthenticationFilter.java
@@ -1,16 +1,9 @@
 package uos.samsam.wing.auth;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.GenericFilterBean;
-import org.springframework.web.filter.OncePerRequestFilter;
-import uos.samsam.wing.domain.user.User;
-import uos.samsam.wing.domain.user.UserRepository;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;

--- a/src/main/java/uos/samsam/wing/auth/JwtTokenProvider.java
+++ b/src/main/java/uos/samsam/wing/auth/JwtTokenProvider.java
@@ -15,9 +15,6 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/uos/samsam/wing/domain/notice/Notice.java
+++ b/src/main/java/uos/samsam/wing/domain/notice/Notice.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import uos.samsam.wing.domain.BaseTimeEntity;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 /**
  * Notice

--- a/src/main/java/uos/samsam/wing/domain/padbox/PadBox.java
+++ b/src/main/java/uos/samsam/wing/domain/padbox/PadBox.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import uos.samsam.wing.domain.report.Report;
 
 import javax.persistence.*;
@@ -72,11 +71,19 @@ public class PadBox {
     }
 
     // 생리대 수량, 온도, 습도 갱신
+    @Deprecated
     public Integer updateState(Integer padAmount, Double temperature, Double humidity) {
         Integer diff = padAmount - this.padAmount;
         this.padAmount = padAmount;
         this.temperature = temperature;
         this.humidity = humidity;
+        this.updatedStateDate = LocalDateTime.now();
+        return diff;
+    }
+
+    public Integer updateState(Integer padAmount) {
+        Integer diff = padAmount - this.padAmount;
+        this.padAmount = padAmount;
         this.updatedStateDate = LocalDateTime.now();
         return diff;
     }

--- a/src/main/java/uos/samsam/wing/service/padbox/PadBoxService.java
+++ b/src/main/java/uos/samsam/wing/service/padbox/PadBoxService.java
@@ -9,7 +9,6 @@ import uos.samsam.wing.domain.padboxlog.PadBoxLog;
 import uos.samsam.wing.domain.padboxlog.PadBoxLogRepository;
 import uos.samsam.wing.web.dto.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -61,7 +60,14 @@ public class PadBoxService {
     public Long updateState(Long id, PadBoxUpdateStateRequestDto requestDto) {
         PadBox padBox = padBoxRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("[id:" + id + "]해당 보관함이 없습니다."));
-        Integer diff = padBox.updateState(requestDto.getPadAmount(), requestDto.getTemperature(), requestDto.getHumidity());
+
+        Integer diff;
+        if (requestDto.getHumidity() != null && requestDto.getTemperature() != null) {
+            diff = padBox.updateState(requestDto.getPadAmount(), requestDto.getTemperature(), requestDto.getHumidity());
+        } else {
+            diff = padBox.updateState(requestDto.getPadAmount());
+        }
+
         if (diff != 0) {
             padBoxLogRepository.save(PadBoxLog.builder()
                     .padBox(padBox)

--- a/src/main/java/uos/samsam/wing/service/report/ReportService.java
+++ b/src/main/java/uos/samsam/wing/service/report/ReportService.java
@@ -7,7 +7,9 @@ import uos.samsam.wing.domain.padbox.PadBox;
 import uos.samsam.wing.domain.padbox.PadBoxRepository;
 import uos.samsam.wing.domain.report.Report;
 import uos.samsam.wing.domain.report.ReportRepository;
-import uos.samsam.wing.web.dto.*;
+import uos.samsam.wing.web.dto.ReportResponseDto;
+import uos.samsam.wing.web.dto.ReportSaveRequestDto;
+import uos.samsam.wing.web.dto.ReportUpdateRequestDto;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/uos/samsam/wing/web/dto/NoticeResponseDto.java
+++ b/src/main/java/uos/samsam/wing/web/dto/NoticeResponseDto.java
@@ -2,7 +2,6 @@ package uos.samsam.wing.web.dto;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import uos.samsam.wing.domain.notice.Notice;

--- a/src/main/java/uos/samsam/wing/web/dto/PadBoxUpdateStateRequestDto.java
+++ b/src/main/java/uos/samsam/wing/web/dto/PadBoxUpdateStateRequestDto.java
@@ -17,15 +17,25 @@ public class PadBoxUpdateStateRequestDto {
 
     @ApiModelProperty(value = "남은 생리대 수량")
     private Integer padAmount;
+
+    @Deprecated
     @ApiModelProperty(value = "현재 온도")
     private Double temperature;
+
+    @Deprecated
     @ApiModelProperty(value = "현재 습도")
     private Double humidity;
 
+    @Deprecated
     @Builder
     public PadBoxUpdateStateRequestDto(Integer padAmount, Double temperature, Double humidity) {
         this.padAmount = padAmount;
         this.temperature = temperature;
         this.humidity = humidity;
+    }
+
+    @Builder
+    public PadBoxUpdateStateRequestDto(Integer padAmount) {
+        this.padAmount = padAmount;
     }
 }

--- a/src/main/java/uos/samsam/wing/web/dto/ReportResponseDto.java
+++ b/src/main/java/uos/samsam/wing/web/dto/ReportResponseDto.java
@@ -4,7 +4,6 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import uos.samsam.wing.domain.padbox.PadBox;
 import uos.samsam.wing.domain.report.Report;
 import uos.samsam.wing.domain.report.ReportTag;
 

--- a/src/main/java/uos/samsam/wing/web/dto/ReportSaveRequestDto.java
+++ b/src/main/java/uos/samsam/wing/web/dto/ReportSaveRequestDto.java
@@ -9,8 +9,6 @@ import uos.samsam.wing.domain.padbox.PadBox;
 import uos.samsam.wing.domain.report.Report;
 import uos.samsam.wing.domain.report.ReportTag;
 
-import java.util.Optional;
-
 /**
  * ReportSaveRequestDto
  * 신고 저장 api로 전달되는 http request DTO입니다.

--- a/src/test/java/uos/samsam/wing/service/notice/NoticeServiceTest.java
+++ b/src/test/java/uos/samsam/wing/service/notice/NoticeServiceTest.java
@@ -34,7 +34,7 @@ class NoticeServiceTest {
     }
 
     @Test
-    void 공지_저장_조회() {
+    void 공지_저장_조회() throws Exception {
         //given
         String title = "테스트 제목";
         String content = "테스트 내용";
@@ -46,6 +46,7 @@ class NoticeServiceTest {
         //when
         Long noticeId = noticeService.save(requestDto);
 
+        Thread.sleep(1000);
         //then
         NoticeResponseDto responseDto = noticeService.findById(noticeId);
         assertThat(responseDto.getTitle()).isEqualTo(title);

--- a/src/test/java/uos/samsam/wing/service/padbox/PadBoxServiceTest.java
+++ b/src/test/java/uos/samsam/wing/service/padbox/PadBoxServiceTest.java
@@ -125,7 +125,7 @@ class PadBoxServiceTest {
     }
 
     @Test
-    void PadBox_상태_갱신_테스트() {
+    void PadBox_상태_갱신_테스트() throws Exception {
         // given
         Double latitude = 37.583458;
         Double longitude = 127.058305;
@@ -146,6 +146,8 @@ class PadBoxServiceTest {
         Long id = padBoxService.save(saveRequestDto);
 
         LocalDateTime now = LocalDateTime.now();
+        Thread.sleep(500);  // to fix timing issue
+
         Integer nextPadAmount = 0;
         Double nextTemperature = 23.0;
         Double nextHumidity = 34.0;

--- a/src/test/java/uos/samsam/wing/service/report/ReportServiceTest.java
+++ b/src/test/java/uos/samsam/wing/service/report/ReportServiceTest.java
@@ -38,7 +38,7 @@ class ReportServiceTest {
     }
 
     @Test
-    void 신고_저장_조회() {
+    void 신고_저장_조회() throws Exception {
         //given
         ReportTag tag = ReportTag.BROKEN;
         String content = "테스트 내용";
@@ -64,6 +64,7 @@ class ReportServiceTest {
         //when
         Long reportId = reportService.save(requestDto);
 
+        Thread.sleep(500);
         //then
         ReportResponseDto responseDto = reportService.findById(reportId);
         assertThat(responseDto.getPadBoxId()).isEqualTo(savedPadBoxId);


### PR DESCRIPTION
1. `LocalDateTime` 활용하는 테스트에서 타이밍 이슈로 테스트 실패하는 문제 해결
  - `Thread.sleep(500)` 걸어줬습니다.
2. 필요없는 import 삭제했습니다.
3. `updateState` API에서 온습도 정보없어도 제대로 동작하도록 수정해놨습니다.
  - 이거 관련해서, 테이블까지 조정할지 아니면 더미로 그냥 남겨둘지 논의 필요
  - 온습도 정보 아예 사용하지 않는다면 추후 테이블, 엔티티도 수정해야 함
  - 근데 API 스펙 수정에 왜 엔티티까지 수정해야하는... 뭔가 이상합니다...